### PR TITLE
feat: expose highlight query in Rust bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,50 @@
-.direnv/
-node_modules/
+# Rust artifacts
 target/
+Cargo.lock
 
-.envrc
+# Node artifacts
+build/
+prebuilds/
+node_modules/
+package-lock.json
 
-# Devenv
-.devenv*
-devenv.local.nix
+# Swift artifacts
+.build/
+Package.resolved
 
-# direnv
-.direnv
+# Go artifacts
+_obj/
 
-# pre-commit
-.pre-commit-config.yaml
+# Python artifacts
+.venv/
+dist/
+*.egg-info
+*.whl
+
+# C artifacts
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.pc
+*.exp
+*.lib
+
+# Zig artifacts
+.zig-cache/
+zig-cache/
+zig-out/
+
+# Example dirs
+/examples/*/
+
+# Grammar volatiles
+*.wasm
+*.obj
+*.o
+
+# Archives
+*.tar.gz
+*.tgz
+*.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "tree-sitter-newick"
-description = "newick grammar for the tree-sitter parsing library"
+description = "A parser for (extended) Newick files (nh, nwk, nhx)"
 version = "1.0.0"
-keywords = ["incremental", "parsing", "newick"]
-categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter-newick"
-edition = "2018"
-license = "MIT"
+authors = ["Franklin Delehelle <github@odena.eu>"]
+license = "CeCILL-C"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tree-sitter", "newick"]
+categories = ["parser-implementations", "parsing", "text-editors"]
+repository = "https://github.com/delehef/tree-sitter-newick"
+edition = "2021"
+autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
@@ -14,18 +17,18 @@ include = [
   "grammar.js",
   "queries/*",
   "src/*",
+  "tree-sitter.json",
+  "/LICENSE",
 ]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.25"
+tree-sitter-language = "0.1"
 
 [build-dependencies]
-cc = "1.0"
+cc = "1.2"
 
-[workspace.metadata.release]
-publish = false
-pre-release-hook = ["git-cliff", "-o", "CHANGELOG.md", "--tag", "{{version}}"]
-allow-branch = ["master"]
+[dev-dependencies]
+tree-sitter = "0.25.9"

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "TreeSitterNewick", targets: ["TreeSitterNewick"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.8.0"),
+        .package(name: "SwiftTreeSitter", url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.8.0"),
     ],
     targets: [
         .target(

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,18 +1,10 @@
-try {
-  module.exports = require("../../build/Release/tree_sitter_newick_binding");
-} catch (error1) {
-  if (error1.code !== 'MODULE_NOT_FOUND') {
-    throw error1;
-  }
-  try {
-    module.exports = require("../../build/Debug/tree_sitter_newick_binding");
-  } catch (error2) {
-    if (error2.code !== 'MODULE_NOT_FOUND') {
-      throw error2;
-    }
-    throw error1
-  }
-}
+const root = require("path").join(__dirname, "..", "..");
+
+module.exports =
+  typeof process.versions.bun === "string"
+    // Support `bun build --compile` by being statically analyzable enough to find the .node file at build-time
+    ? require(`../../prebuilds/${process.platform}-${process.arch}/tree-sitter-newick.node`)
+    : require("node-gyp-build")(root);
 
 try {
   module.exports.nodeTypeInfo = require("../../src/node-types.json");

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
-import tree_sitter
+from tree_sitter import Language, Parser
 import tree_sitter_newick
 
 
 class TestLanguage(TestCase):
     def test_can_load_grammar(self):
         try:
-            tree_sitter.Language(tree_sitter_newick.language())
+            Parser(Language(tree_sitter_newick.language()))
         except Exception:
             self.fail("Error loading Newick grammar")

--- a/bindings/python/tree_sitter_newick/__init__.py
+++ b/bindings/python/tree_sitter_newick/__init__.py
@@ -14,8 +14,8 @@ def _get_query(name, file):
 def __getattr__(name):
     # NOTE: uncomment these to include any queries that this grammar contains:
 
-    # if name == "HIGHLIGHTS_QUERY":
-    #     return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
+    if name == "HIGHLIGHTS_QUERY":
+        return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
     # if name == "INJECTIONS_QUERY":
     #     return _get_query("INJECTIONS_QUERY", "injections.scm")
     # if name == "LOCALS_QUERY":
@@ -28,7 +28,7 @@ def __getattr__(name):
 
 __all__ = [
     "language",
-    # "HIGHLIGHTS_QUERY",
+    "HIGHLIGHTS_QUERY",
     # "INJECTIONS_QUERY",
     # "LOCALS_QUERY",
     # "TAGS_QUERY",

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,39 +2,20 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
-    c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+    c_config.std("c11").include(src_dir);
+
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
-
-    c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
+    let scanner_path = src_dir.join("scanner.c");
+    if scanner_path.exists() {
+        c_config.file(&scanner_path);
+        println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    }
 
-    /*
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
+    c_config.compile("tree-sitter-newick");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -35,7 +35,7 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,44 +1,43 @@
-//! This crate provides newick language support for the [tree-sitter][] parsing library.
+//! This crate provides Newick language support for the [tree-sitter] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
-//! tree-sitter [Parser][], and then use the parser to parse some code:
+//! Typically, you will use the [`LANGUAGE`] constant to add this language to a
+//! tree-sitter [`Parser`], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_newick::language()).expect("Error loading newick grammar");
+//! let language = tree_sitter_newick::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Newick parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
-//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [`Parser`]: https://docs.rs/tree-sitter/0.25.9/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_newick() -> Language;
+    fn tree_sitter_newick() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_newick) };
+
+/// The content of the [`node-types.json`] file for this grammar.
 ///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_newick() }
-}
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-/// The content of the [`node-types.json`][] file for this grammar.
-///
-/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+// NOTE: uncomment these to include any queries that this grammar contains:
 
-// Uncomment these to include any queries that this grammar contains
-
-pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +45,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
-            .expect("Error loading newick language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Newick parser");
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,11 @@
 from os import path
-from platform import system
 from sysconfig import get_config_var
 
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build import build
+from setuptools.command.build_ext import build_ext
 from setuptools.command.egg_info import egg_info
 from wheel.bdist_wheel import bdist_wheel
-
-sources = [
-    "bindings/python/tree_sitter_newick/binding.c",
-    "src/parser.c",
-]
-if path.exists("src/scanner.c"):
-    sources.append("src/scanner.c")
-
-macros: list[tuple[str, str | None]] = [
-    ("PY_SSIZE_T_CLEAN", None),
-    ("TREE_SITTER_HIDE_SYMBOLS", None),
-]
-if limited_api := not get_config_var("Py_GIL_DISABLED"):
-    macros.append(("Py_LIMITED_API", "0x030A0000"))
-
-if system() != "Windows":
-    cflags = ["-std=c11", "-fvisibility=hidden"]
-else:
-    cflags = ["/std:c11", "/utf-8"]
 
 
 class Build(build):
@@ -33,6 +14,19 @@ class Build(build):
             dest = path.join(self.build_lib, "tree_sitter_newick", "queries")
             self.copy_tree("queries", dest)
         super().run()
+
+
+class BuildExt(build_ext):
+    def build_extension(self, ext: Extension):
+        if self.compiler.compiler_type != "msvc":
+            ext.extra_compile_args = ["-std=c11", "-fvisibility=hidden"]
+        else:
+            ext.extra_compile_args = ["/std:c11", "/utf-8"]
+        if path.exists("src/scanner.c"):
+            ext.sources.append("src/scanner.c")
+        if ext.py_limited_api:
+            ext.define_macros.append(("Py_LIMITED_API", "0x030A0000"))
+        super().build_extension(ext)
 
 
 class BdistWheel(bdist_wheel):
@@ -61,15 +55,21 @@ setup(
     ext_modules=[
         Extension(
             name="_binding",
-            sources=sources,
-            extra_compile_args=cflags,
-            define_macros=macros,
+            sources=[
+                "bindings/python/tree_sitter_newick/binding.c",
+                "src/parser.c",
+            ],
+            define_macros=[
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
+            ],
             include_dirs=["src"],
-            py_limited_api=limited_api,
+            py_limited_api=not get_config_var("Py_GIL_DISABLED"),
         )
     ],
     cmdclass={
         "build": Build,
+        "build_ext": BuildExt,
         "bdist_wheel": BdistWheel,
         "egg_info": EggInfo,
     },


### PR DESCRIPTION
Thanks a lot for the crates.io upload!
Here's a small detail - it's not critical for us so no need to do another release just for it as far as I am concerned.

I have also used this opportunity to re-generate the Rust bindings so that they offer the newer API that tree-sitter 0.25 users normally expect (although it's possible to use the crate as it stands). It also fixes issues in the crate metadata, in Cargo.toml.