### PR TITLE
Restore license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "tree-sitter-newick"
 description = "A parser for (extended) Newick files (nh, nwk, nhx)"
 version = "1.1.0"
 authors = ["Franklin Delehelle <github@odena.eu>"]
+license = "CECILL-C"
 license-file = "LICENSE.txt"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "newick"]


### PR DESCRIPTION
https://github.com/michel-slm/tree-sitter-newick/commit/159967e38a5f579129ab656cd76eab6f8beae161 replaced the `license` field with `license-file`. Both are actually valid, but Fedora tooling relies on `license`

Note that
https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields prefers `license` as well, unless the license is non-standard; I changed the wording from CeCILL-C to CECILL-C to match the SPDX list in https://spdx.org/licenses/